### PR TITLE
Improvements/Fixes

### DIFF
--- a/autoruns.py
+++ b/autoruns.py
@@ -1,17 +1,13 @@
 import sys
 import re
-
 import xml.etree.ElementTree as ET
 import volatility.debug as debug
-import volatility.win32.rawreg as rawreg
 import volatility.plugins.registry.registryapi as registryapi
-import volatility.plugins.registry.hivelist as hivelist
 import volatility.plugins.filescan as filescan
 import volatility.plugins.dumpfiles as dumpfiles
-import volatility.win32.hive as hivemod
 import volatility.win32 as win32
-import volatility.obj as obj
 import volatility.utils as utils
+import volatility.plugins.common as common
 from volatility.renderers import TreeGrid
 
 # HKLM\Software\
@@ -42,11 +38,10 @@ NTUSER_RUN_KEYS = [
 ]
 
 
-# Acitve Setup only executes commands from the SOFTWARE hive
+# Active Setup only executes commands from the SOFTWARE hive
 # See: https://helgeklein.com/blog/2010/04/active-setup-explained/
 #      http://blogs.msdn.com/b/aruns_blog/archive/2011/06/20/active-setup-registry-key-what-it-is-and-how-to-create-in-the-package-using-admin-studio-install-shield.aspx
 #      http://blog.spiderlabs.com/2014/07/backoff-technical-analysis.html
-
 ACTIVE_SETUP_KEY = "Microsoft\\Active Setup\\Installed Components"
 
 
@@ -54,13 +49,11 @@ ACTIVE_SETUP_KEY = "Microsoft\\Active Setup\\Installed Components"
 # References:
 # https://www.blackhat.com/docs/asia-14/materials/Erickson/WP-Asia-14-Erickson-Persist-It-Using-And-Abusing-Microsofts-Fix-It-Patches.pdf
 # http://blog.cert.societegenerale.com/2015/04/analyzing-gootkits-persistence-mechanism.html
-
 APPCOMPAT_SDB_KEY = "Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB"
 
 
 # Winlogon Notification packages are supported in pre-Vista versions of Windows only
 # See: http://technet.microsoft.com/en-us/library/cc721961(v=ws.10).aspx
-
 WINLOGON_NOTIFICATION_EVENTS = [
     "Lock",
     "Logoff",
@@ -94,7 +87,7 @@ WINLOGON_COMMON_VALUES = {
 # Service key -> value maps
 # Original list from regripper plugins, extra / repeated values from
 # http://technet.microsoft.com/en-us/library/cc759275(v=ws.10).aspx
-service_types = {
+SERIVCE_TYPES = {
     0x001: "Kernel driver",
     0x002: "File system driver",
     0x004: "Arguments for adapter",
@@ -107,7 +100,7 @@ service_types = {
     -1: "Unknown",
 }
 
-service_startup = {
+SERIVCE_STARTUP = {
     0x00: "Boot Start",
     0x01: "System Start",
     0x02: "Auto Start",
@@ -117,16 +110,20 @@ service_startup = {
 }
 
 
-def sanitize_paths(path):
+def sanitize_path(path):
     # Clears the path of most equivalent forms
-    path = path.lower()
-    path = path.replace("%systemroot%\\", '')
-    path = path.replace("\\systemroot\\", '')
-    path = path.replace("%windir%", '')
-    path = path.replace("\\??\\", '')
-    path = path.replace('\x00', '')
-    path = path.replace('"', '').replace("'", '')
-    return path
+    if path:
+        path = path.lower()
+        path = path.replace("%systemroot%\\", '')
+        path = path.replace("\\systemroot\\", '')
+        path = path.replace("%windir%", '')
+        path = path.replace("\\??\\", '')
+        path = path.replace('\x00', '')
+        path = path.replace('"', '').replace("'", '')
+        return path
+
+    else:
+        return ''
 
 
 def get_indented_dict(d, depth=0):
@@ -144,334 +141,386 @@ def get_indented_dict(d, depth=0):
     return output
 
 
-class Autoruns(hivelist.HiveList):
+class Autoruns(common.AbstractWindowsCommand):
     """Searches the registry and memory space for applications running at system startup and maps them to running processes"""
     def __init__(self, config, *args, **kwargs):
-        hivelist.HiveList.__init__(self, config, *args, **kwargs)
-
+        common.AbstractWindowsCommand.__init__(self, config, *args, **kwargs)
         config.add_option("ASEP-TYPE", short_option='t', default=None,
-                          help='Show these ASEP types: autoruns, services, appinit, winlogon, tasks, sdb (comma-separated)',
+                          help='Only collect the ASEP types specified. Select from: autoruns, services, appinit, winlogon, tasks, activesetup, sdb (comma-separated)',
                           action='store', type='str')
-
+        config.remove_option("VERBOSE")
         config.add_option("VERBOSE", short_option='v', default=False,
-                          help='Verbose output: display less relevant results',
+                          help='Show entries that are normally filtered out (Ex. Services from the System32 folder)',
                           action='store_true')
 
-        self.regapi = registryapi.RegistryApi(self._config)
+        self.process_dict = {}
+        self.autoruns = []
+        self.services = []
+        self.appinit_dlls = []
+        self.winlogon = []
+        self.winlogon_registrations = []
+        self.tasks = []
+        self.activesetup = []
+        self.sdb = []
 
     def get_dll_list(self):
         addr_space = utils.load_as(self._config)
         task_objects = win32.tasks.pslist(addr_space)
-        self.process_dict = {}
         for task in task_objects:
             if task.Peb:
                 self.process_dict[int(task.UniqueProcessId)] = (task, [m for m in task.get_load_modules()])
 
+    # Matches a given module (executable, DLL) to a running process by looking either
+    # in the CommandLine parameters or in the loaded modules
     def find_pids_for_imagepath(self, module):
         pids = []
-        # Matches a given module (executable, DLL) to a running process by looking either
-        # in the CommandLine parameters or in the loaded modules
-        module = sanitize_paths(module)
+        module = sanitize_path(module)
         if module:
             for pid in self.process_dict:
                 # case where the image path matches the process' command-line information
                 if self.process_dict[pid][0].Peb:
                     cmdline = self.process_dict[pid][0].Peb.ProcessParameters.CommandLine
-                    if module.lower() in sanitize_paths(str(cmdline or '[no cmdline]').lower()):
+                    if module in sanitize_path(str(cmdline or '[no cmdline]')):
                         pids.append(pid)
 
                 # case where the module is actually loaded process (case for DLLs loaded by services)
                 for dll in self.process_dict[pid][1]:
-                    if module.lower() in sanitize_paths(str(dll.FullDllName or '[no dllname]').lower()):
+                    if module in sanitize_path(str(dll.FullDllName or '[no dllname]')):
                         pids.append(pid)
 
         return list(set(pids))
 
-    def hive_name(self, hive):
-        try:
-            return hive.FileFullPath.v() or hive.FileUserName.v() or hive.HiveRootPath.v() or "[no name]"
-        except AttributeError:
-            return "[no name]"
-
-    def dict_for_key(self, key):
-        # Inspired from the Volatility printkey plugin
-        valdict = {}
-        if not key:
-            return valdict
-        for v in rawreg.values(key):
-            tp, data = rawreg.value_data(v)
-
-            if tp == 'REG_BINARY' or tp == 'REG_NONE':
-                data = "\n" + "\n".join(["{0:#010x}  {1:<48}  {2}".format(o, h, ''.join(c)) for o, h, c in utils.Hexdump(data)])
-            if tp in ['REG_SZ', 'REG_EXPAND_SZ', 'REG_LINK']:
-                data = data.encode("ascii", 'backslashreplace')
-            if tp == 'REG_MULTI_SZ':
-                for i in range(len(data)):
-                    data[i] = data[i].encode("ascii", 'backslashreplace')
-
-            valdict[str(v.Name)] = str(data)
-        return valdict
-
+    # Returns [] or a list of tuples(dll, key path, key.LastWriteTime, [int(pids)])
     def get_appinit_dlls(self):
 
-        self.regapi.set_current(hive_name="software")
-        appinit_values = self.regapi.reg_get_value(hive_name='software', key="Microsoft\\Windows NT\\CurrentVersion\\Windows", value='AppInit_DLLs')
-        if appinit_values:
-            appinit_dlls = appinit_values.replace('\x00', '').split(' ')
+        debug.debug('Started get_appinit_dlls()')
+        key_path="Microsoft\\Windows NT\\CurrentVersion\\Windows"
+        results = []
 
-            if len(appinit_dlls) > 0:
-                return appinit_dlls
-            else:
-                return None
+        try:
+            self.regapi.reset_current()
+            key = self.regapi.reg_get_key(hive_name='software', key=key_path)
+            appinit_values = self.regapi.reg_get_value(None, None, value='AppInit_DLLs', given_root=key)
+
+        except Exception as e:
+            debug.warning('get_appinit_dlls() failed to complete. Exception: {} {}'.format(type(e).__name__, e.args))
+
+        else:
+            if appinit_values:
+                # Split on space or comma: https://msdn.microsoft.com/en-us/library/windows/desktop/dd744762(v=vs.85).aspx
+                appinit_dlls = str(appinit_values).replace('\x00', '').replace(',', ' ').split(' ')
+                results = [(dll, key_path, key.LastWriteTime, "AppInit_DLLs", self.find_pids_for_imagepath(dll)) for dll in appinit_dlls if dll]
+
+        debug.debug('Finished get_appinit_dlls()')
+        return results
 
     # Winlogon Notification packages are supported in pre-Vista versions of Windows only
     # See: http://technet.microsoft.com/fr-fr/library/cc721961(v=ws.10).aspx
+    # returns [] or a list of tuples from parse_winlogon_registration_key()
     def get_winlogon_registrations(self):
-        self.regapi.set_current(hive_name="software")
 
-        winlogon_registrations = []
-        for subkey in self.regapi.reg_get_all_subkeys(hive_name='software', key="Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Notify"):
-            reg = self.parse_winlogon_registration_key(subkey)
-            if reg:
-                if (self._config.VERBOSE) or (not self._config.VERBOSE and reg[0].split('\\')[-1] not in WINLOGON_REGISTRATION_KNOWN_DLLS):
-                    winlogon_registrations.append(reg)
+        debug.debug('Started get_winlogon_registrations()')
+        results = []
+        notify_key = "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Notify"
 
-        return winlogon_registrations
+        try:
+            self.regapi.reset_current()
+            for subkey in self.regapi.reg_get_all_subkeys(hive_name='software', key=notify_key):
+                parsed_entry = self.parse_winlogon_registration_key(subkey)
+                if parsed_entry and (self._config.VERBOSE or (parsed_entry[0].split('\\')[-1] not in WINLOGON_REGISTRATION_KNOWN_DLLS)):
+                    results.append(parsed_entry)
 
-    def get_winlogon(self):
-        self.regapi.set_current(hive_name="software")
+        except Exception as e:
+            debug.warning('get_winlogon_registrations() failed to complete. Exception: {0} {1}'.format(type(e).__name__, e.args))
 
-        winlogon = []
-        winlogon_key = self.regapi.reg_get_key(hive_name='software', key="Microsoft\\Windows NT\\CurrentVersion\\Winlogon")
-        if winlogon_key:
-            valdict = self.dict_for_key(winlogon_key)
-            timestamp = winlogon_key.LastWriteTime
+        debug.debug('Finished get_winlogon_registrations()')
+        return results
 
-            for value in valdict:
-                if value in WINLOGON_COMMON_VALUES:
-                    pids = self.find_pids_for_imagepath(valdict[value])
-                    winlogon.append((value, valdict[value].replace('\x00', ''), timestamp, WINLOGON_COMMON_VALUES[str(value)], pids))
-
-        return winlogon
-
+    # Returns None or (str(dllname), [(str(trigger)),str(event))], key.LastWriteTime, key path, [int(pids)])
     def parse_winlogon_registration_key(self, key):
 
-        name = str(key.Name)
-
-        k = self.dict_for_key(key)
-        events = [(evt, k[evt].replace('\x00', '')) for evt in WINLOGON_NOTIFICATION_EVENTS if evt in k]
-
         dllname = ""
-        for dictkey in k:
-            # Nasty hack; the variable "DLLName" has no consistent case
-            if dictkey.lower() == 'dllname':
-                dllname = k[dictkey]
-
+        events = []
         pids = []
+        key_path = self.regapi.reg_get_key_path(key) or str(key.Name)
+
+        try:
+            for v_name, v_data in self.regapi.reg_yield_values(hive_name=None, key=None, given_root=key):
+                val_name = str(v_name or '')
+                val_data = str(v_data or '').replace('\x00', '')
+
+                if val_name.lower() == 'dllname':
+                    dllname = val_data
+                    pids = self.find_pids_for_imagepath(dllname)
+                elif val_name in WINLOGON_NOTIFICATION_EVENTS:
+                    events.append((val_name, val_data))
+
+        except Exception as e:
+            debug.warning('Failed while parsing {}. Exception: {} {}'.format(key_path, type(e).__name__, e.args))
+
         if dllname:
-            pids = self.find_pids_for_imagepath(dllname)
+            return (dllname, events, key.LastWriteTime, key_path, pids)
 
-        return (dllname.replace('\x00', ''), events, key.LastWriteTime, pids, name)
+    # Returns [] or a list of tuples(val_name, val_data, key.LastWriteTime, expected_val_data, [int(pids)])
+    def get_winlogon(self):
 
+        debug.debug('Started get_winlogon()')
+        winlogon = []
+        winlogon_key_path="Microsoft\\Windows NT\\CurrentVersion\\Winlogon"
+
+        try:
+            self.regapi.reset_current()
+            key = self.regapi.reg_get_key(hive_name='software', key=winlogon_key_path)
+            if key:
+                for v_name, v_data in self.regapi.reg_yield_values(hive_name=None, key=None, given_root=key):
+                    val_name = str(v_name or '')
+                    val_data = str(v_data or '').replace('\x00', '')
+
+                    if val_data and val_name in WINLOGON_COMMON_VALUES:
+                        pids = self.find_pids_for_imagepath(val_data)
+                        winlogon.append((val_name, val_data, key.LastWriteTime, WINLOGON_COMMON_VALUES[val_name], winlogon_key_path, pids))
+
+        except Exception as e:
+            debug.warning('get_winlogon() failed to complete. Exception: {} {}'.format(type(e).__name__, e.args))
+
+        debug.debug('Finished get_winlogon()')
+        return winlogon
+
+    # Returns [] or a list of tuples from parse_service_key()
+    def get_services(self):
+
+        debug.debug('Started get_services()')
+        results = []
+        service_key_path = "{}\\Services".format(self.currentcs)
+
+        try:
+            self.regapi.reset_current()
+            for service_sk in self.regapi.reg_get_all_subkeys(hive_name='system', key=service_key_path):
+                parsed_service = self.parse_service_key(service_sk)
+                if parsed_service and (self._config.VERBOSE or 'system32' not in parsed_service[5].lower()):
+                    results.append(parsed_service)
+
+        except Exception as e:
+            debug.warning('get_services() failed to complete. Exception: {0} {1}'.format(type(e).__name__, e.args))
+
+        debug.debug('Finished get_services()')
+        return results
+
+    # Returns None or (key_path, timestamp, display_name, SERIVCE_STARTUP[startup], SERIVCE_TYPES[type], image_path, service_dll, [int(pids)])
     def parse_service_key(self, service_key):
 
-        name = str(service_key.Name)
+        try:
+            values = {str(val_name): str(val_data).replace('\x00', '') for val_name, val_data in self.regapi.reg_yield_values(None, None, given_root=service_key)}
 
-        values = {str(name): str(dat) for name, dat in self.regapi.reg_yield_values(hive_name='system', key='', given_root=service_key)}
+            image_path = values.get("ImagePath", '')
+            display_name = values.get("DisplayName",'')
+            service_dll = values.get("ServiceDll", '')
+            main = values.get("ServiceMain", '')
+            startup = int(values.get("Start", -1))
+            type = int(values.get("Type", -1))
+            timestamp = service_key.LastWriteTime
+            key_path = self.regapi.reg_get_key_path(service_key) or str(service_key.Name)
 
-        image_path = values.get("ImagePath", None)
-        if not image_path:
-            return
+            # Check if the service is not set to automatically start or does not have an image path
+            # More details here: http://technet.microsoft.com/en-us/library/cc759637(v=ws.10).aspx
+            if not image_path or startup not in [0, 1, 2]:
+                return None
 
-        display_name = values.get("DisplayName",'')
-        entry = values.get("ServiceDll", '')
-        main = values.get("ServiceMain", '')
-        startup = int(values.get("Start", -1))
-        type = int(values.get("Type", -1))
+            if 'svchost.exe -k' in image_path.lower() or SERIVCE_TYPES[type] == 'Share_Process':
+                sk = self.regapi.reg_get_key(hive_name='system', key='Parameters', given_root=service_key)
+                if sk and not service_dll:
+                    timestamp = sk.LastWriteTime
+                    service_dll = self.regapi.reg_get_value(hive_name='system', key='', value="ServiceDll", given_root=sk)
+                    main = self.regapi.reg_get_value(hive_name='system', key='', value='ServiceMain', given_root=sk)
 
-        timestamp = service_key.LastWriteTime
+                if not service_dll and '@' in display_name:
+                    timestamp = service_key.LastWriteTime
+                    service_dll = display_name.split('@')[1].split(',')[0]
 
-        if 'svchost.exe -k' in image_path.lower() or service_types[type] == 'Share_Process':
-            sk = self.regapi.reg_get_key(hive_name='system', key='Parameters', given_root=service_key)
-            if sk and not entry:
-                timestamp = sk.LastWriteTime
-                entry = self.regapi.reg_get_value(hive_name='system', key='', value="ServiceDll", given_root=sk)
-                main = self.regapi.reg_get_value(hive_name='system', key='', value='ServiceMain', given_root=sk) 
-
-            if not entry and '@' in display_name:
-                timestamp = service_key.LastWriteTime
-                entry = display_name[display_name.find('@')+1:].split(',')[0]
-
-        if entry:
-            entry = entry.replace('\x00', '')
-            if main:
-                main = main.replace('\x00', '')
-                entry += " ({})".format(main)
-
-        # Check if the service is set to automatically start
-        # More details here: http://technet.microsoft.com/en-us/library/cc759637(v=ws.10).aspx
-
-        if startup in [0, 1, 2]:
-            if entry:
-                pids = self.find_pids_for_imagepath(entry.split('(')[0].strip())
+            if service_dll:
+                service_dll = service_dll.replace('\x00', '')
+                pids = self.find_pids_for_imagepath(service_dll)
+                if main:
+                    service_dll = "{} ({})".format(service_dll, main.replace('\x00', ''))
             else:
                 pids = self.find_pids_for_imagepath(image_path)
 
-            return (name, timestamp, display_name, service_startup[startup], service_types[type], image_path, entry, pids)
+        except Exception as e:
+            debug.warning('Failed while parsing {}. Exception: {} {}'.format(key_path, type(e).__name__, e.args))
 
-    def get_services(self):
-        # Get the CurrentControlSet symlink
-        currentcs = self.regapi.reg_get_currentcontrolset()
-        if currentcs is None:
-            currentcs = "ControlSet001"
+        return (key_path, timestamp, display_name, SERIVCE_STARTUP[startup], SERIVCE_TYPES[type], image_path, service_dll, pids)
 
-        services = []
-        self.regapi.set_current(hive_name="system")
-        for service in self.regapi.reg_get_all_subkeys(hive_name='system', key="{}\\Services".format(currentcs)):
-            service = self.parse_service_key(service)
-            if service:
-                if (self._config.VERBOSE) or (not self._config.VERBOSE and 'system32' not in service[5].lower() and service[5] != "Unknown"):
-                    services.append(service)
-
-        return services
-
+    # Returns [] or a list of tuples from parse_activesetup_keys()
     def get_activesetup(self):
-        self.regapi.set_current(hive_name="software")
-        activesetup_keys = self.regapi.reg_get_all_subkeys(hive_name='software', key=ACTIVE_SETUP_KEY)
+
+        debug.debug('Started get_activesetup()')
         results = []
 
-        for subkey in activesetup_keys:
-            r = self.parse_activesetup_keys(subkey)
-            if r:
-                results.append(r)
+        try:
+            self.regapi.reset_current()
+            for subkey in self.regapi.reg_get_all_subkeys(hive_name='software', key=ACTIVE_SETUP_KEY):
+                r = self.parse_activesetup_keys(subkey)
+                if r:
+                    results.append(r)
 
+        except Exception as e:
+            debug.warning('get_activesetup() failed to complete. Exception: {0} {1}'.format(type(e).__name__, e.args))
+
+        debug.debug('Finished get_activesetup()')
         return results
 
+    # Returns None or a tuple(exe path, subkey.LastWriteTime, key path, [int(pids)])
     def parse_activesetup_keys(self, subkey):
-        valdict = self.dict_for_key(subkey)
-        if 'StubPath' in valdict and valdict.get('StubPath', '').replace('\x00', ''):
-            pids = self.find_pids_for_imagepath(valdict['StubPath'])
-            return (valdict['StubPath'].replace('\x00', ''), subkey.LastWriteTime, pids)
-        else:
-            return None
 
+        key_path = self.regapi.reg_get_key_path(subkey) or str(subkey.Name)
+
+        try:
+            stub_path_val = self.regapi.reg_get_value(hive_name='software', key='', value='StubPath', given_root=subkey)
+            stub_path_val = str(stub_path_val or '').replace('\x00', '')
+        except Exception as e:
+            debug.warning('Failed while parsing {}. Exception: {} {}'.format(key_path, type(e).__name__, e.args))
+
+        if stub_path_val:
+            pids = self.find_pids_for_imagepath(stub_path_val)
+            return (stub_path_val, subkey.LastWriteTime, key_path, pids)
+
+    # Returns [] or a list of tuples from parse_sdb_key()
     def get_sdb(self):
-        self.regapi.set_current(hive_name="software")
-        sdb_keys = self.regapi.reg_get_all_subkeys(hive_name='software', key=APPCOMPAT_SDB_KEY)
+
+        debug.debug('Started get_sdb()')
         results = []
 
-        for subkey in sdb_keys:
-            r = self.parse_sdb_key(subkey)
-            if r:
-                results.append(r)
+        try:
+            self.regapi.reset_current()
+            sdb_keys = self.regapi.reg_get_all_subkeys(hive_name='software', key=APPCOMPAT_SDB_KEY)
+            for subkey in sdb_keys:
+                parsed_sdb_entry = self.parse_sdb_key(subkey)
+                if parsed_sdb_entry:
+                    results.append(parsed_sdb_entry)
 
+        except Exception as e:
+            debug.warning('get_sdb() failed to complete. Exception: {0} {1}'.format(type(e).__name__, e.args))
+
+        debug.debug('Finished get_sdb()')
         return results
 
+    #Returns None or a tuple(exe, db_path, subkey.LastWriteTime, key path, [int(pids)])
     def parse_sdb_key(self, subkey):
-        valdict = self.dict_for_key(subkey)
-        desc = sanitize_paths(valdict['DatabaseDescription'])
-        timestamp = subkey.LastWriteTime
-        path = sanitize_paths(valdict['DatabasePath'])
-        pids = self.find_pids_for_imagepath(desc)
 
-        return (desc, path, timestamp, pids)
+        key_path = self.regapi.reg_get_key_path(subkey) or str(subkey.Name)
 
+        try:
+            desc = sanitize_path(self.regapi.reg_get_value('software', '', 'DatabaseDescription', subkey) or '')
+            db_path = sanitize_path(self.regapi.reg_get_value('software', '', 'DatabasePath', subkey) or '')
+            pids = self.find_pids_for_imagepath(desc)
+        except Exception as e:
+            debug.warning('Failed while parsing {}. Exception: {} {}'.format(key_path, type(e).__name__, e.args))
+
+        if desc:
+            return (desc, db_path, subkey.LastWriteTime, key_path, pids)
+
+    # Returns [] or a list of tuples from parse_autoruns_key()
     def get_autoruns(self):
-        debug.debug("Getting offsets")
-        addr_space = utils.load_as(self._config)
-        hive_offsets = [h.obj_offset for h in hivelist.HiveList.calculate(self)]
-        debug.debug("Found %s hives" % len(hive_offsets))
-        hives = {}
-        ntuser_hive_roots = []
 
-        # Cycle through all hives until we find NTUSER.DAT or SOFTWARE
-        # This enables us to search all memory-resident NTUSER.DAT hives
-
-        for hoff in set(hive_offsets):
-            h = hivemod.HiveAddressSpace(addr_space, self._config, hoff)
-
-            name = self.hive_name(obj.Object("_CMHIVE", vm=addr_space, offset=hoff))
-            root = rawreg.get_root(h)
-
-            if 'ntuser.dat' in name.split('\\')[-1].lower():
-                keys = NTUSER_RUN_KEYS
-                ntuser_hive_roots.append(root)
-            elif 'software' in name.split('\\')[-1].lower():
-                keys = SOFTWARE_RUN_KEYS
-            elif 'system' in name.split('\\')[-1].lower():
-                continue
-            else:
-                continue
-
-            debug.debug("Searching for keys in %s" % name)
-
-            for full_key in keys:
-                results = []
-                debug.debug("  Opening %s" % (full_key))
-                key = rawreg.open_key(root, full_key.split('\\'))
-                results = self.parse_autoruns_key(key)
-
-                if len(results) > 0:
-                    h = hives.get(name, {})
-                    h[(full_key, key.LastWriteTime)] = results
-                    hives[name] = h
-
-        return hives
-
-    def parse_autoruns_key(self, key):
-
-        valdict = self.dict_for_key(key)
+        debug.debug('Started get_autoruns()')
         results = []
-        for v in valdict:
-            if valdict[v] not in ["", None, "\x00"]:
-                pids = self.find_pids_for_imagepath(valdict[v])
-                results.append((v, valdict[v].replace('\x00', ''), pids))
+        hive_key_list = []
+
+        try:
+            # Gather all software run keys
+            self.regapi.reset_current()
+            for run_key in SOFTWARE_RUN_KEYS:
+                hive_key_list += [k for k in self.regapi.reg_yield_key(hive_name='software', key=run_key)]
+
+            # Gather all ntuser run keys
+            self.regapi.reset_current()
+            for run_key in NTUSER_RUN_KEYS:
+                hive_key_list += [k for k in self.regapi.reg_yield_key(hive_name='ntuser.dat', key=run_key)]
+
+            # hive_key = (key pointer, hive_name)
+            for hive_key in hive_key_list:
+                results += self.parse_autoruns_key(hive_key)
+
+        except Exception as e:
+            debug.warning('get_autoruns() failed to complete. Exception: {0} {1}'.format(type(e).__name__, e.args))
+
+        debug.debug('Finished get_autoruns()')
+        return results
+
+    # Returns [] or a list of tuples(exe path, hive name, key path, key.LastWriteTime, value name, [int(pids)])
+    def parse_autoruns_key(self, hive_key):
+
+        results = []
+        key = hive_key[0]
+        hive_name = hive_key[1]
+        key_path = self.regapi.reg_get_key_path(key) or str(key.Name)
+
+        try:
+            # val_data is the exe path
+            for v_name, v_data in self.regapi.reg_yield_values(None, None, given_root=key):
+                val_name = str(v_name or '')
+                val_data = str(v_data or '').replace('\x00', '')
+
+                if val_data:
+                    pids = self.find_pids_for_imagepath(val_data)
+                    results.append((val_data, hive_name, key_path, key.LastWriteTime, val_name, pids))
+
+        except Exception as e:
+            debug.warning('Failed while parsing {}. Exception: {} {}'.format(key_path, type(e).__name__, e.args))
 
         return results
 
     def get_tasks(self):
+
+        debug.debug('Started get_tasks()')
         addr_space = utils.load_as(self._config)
         f = filescan.FileScan(self._config)
         tasks = []
         parsed_tasks = []
-        for file in f.calculate():
-            filename = str(file.file_name_with_device() or '')
-            if "system32\\tasks\\" in filename.lower() and ('system32\\tasks\\microsoft' not in filename.lower() or self._config.VERBOSE):
-                tasks.append((file.obj_offset, filename))
-                debug.debug("Found task: 0x{0:x} {1}".format(file.obj_offset, filename))
 
-        for offset, name in tasks:
+        try:
+            for file in f.calculate():
+                filename = str(file.file_name_with_device() or '')
+                if "system32\\tasks\\" in filename.lower() and (('system32\\tasks\\microsoft' not in filename.lower() or self._config.VERBOSE)):
+                    tasks.append((file.obj_offset, filename))
+                    debug.debug("Found task: 0x{0:x} {1}".format(file.obj_offset, filename))
 
-            self._config.PHYSOFFSET = '0x{:x}'.format(offset)
-            df = dumpfiles.DumpFiles(self._config)
-            self._config.DUMP_DIR = '.'
-            for data in df.calculate():
-                # Doing this with mmap would probably be cleaner
-                # Create a sufficiently large (dynamically resizable?)
-                # memory map so that we can seek and write the file accordingly
-                #
-                # SystemError: mmap: resizing not available--no mremap()
+            for offset, name in tasks:
 
-                chopped_file = {}
+                self._config.PHYSOFFSET = '0x{:x}'.format(offset)
+                df = dumpfiles.DumpFiles(self._config)
+                self._config.DUMP_DIR = '.'
+                for data in df.calculate():
+                    # Doing this with mmap would probably be cleaner
+                    # Create a sufficiently large (dynamically resizable?)
+                    # memory map so that we can seek and write the file accordingly
+                    #
+                    # SystemError: mmap: resizing not available--no mremap()
 
-                for mdata in data['present']:
-                    rdata = addr_space.base.read(mdata[0], mdata[2])
-                    chopped_file[mdata[1]] = rdata
+                    chopped_file = {}
 
-                task_xml = "".join(part[1] for part in sorted(chopped_file.items(), key=lambda x: x[0]))
+                    for mdata in data['present']:
+                        rdata = addr_space.base.read(mdata[0], mdata[2])
+                        chopped_file[mdata[1]] = rdata
 
-                parsed = self.parse_task_xml(task_xml)
+                    task_xml = "".join(part[1] for part in sorted(chopped_file.items(), key=lambda x: x[0]))
 
-                if parsed:
-                    args = parsed['Actions']['Exec'].get("Arguments", None)
-                    if args:
-                        parsed['Actions']['Exec']['Command'] += " {}".format(args)
-                    pids = self.find_pids_for_imagepath(parsed['Actions']['Exec']['Command'])
-                    parsed_tasks.append((name.split('\\')[-1], parsed, task_xml, pids))
+                    parsed = self.parse_task_xml(task_xml, name)
 
+                    if parsed:
+                        args = parsed['Actions']['Exec'].get("Arguments", None)
+                        if args:
+                            parsed['Actions']['Exec']['Command'] += " {}".format(args)
+                        pids = self.find_pids_for_imagepath(parsed['Actions']['Exec']['Command'])
+                        parsed_tasks.append((name.split('\\')[-1], parsed, task_xml, pids))
+
+        except Exception as e:
+            debug.warning('get_tasks() failed to complete. Exception: {0} {1}'.format(type(e).__name__, e.args))
+
+        debug.debug('Finished get_tasks()')
         return parsed_tasks
 
-    def parse_task_xml(self, xml):
+    def parse_task_xml(self, xml, f_name):
         raw = xml
         xml = re.sub('\x00\x00+', '', xml) + '\x00'
         if xml:
@@ -484,15 +533,15 @@ class Autoruns(hivelist.HiveList):
                 d = {}
 
                 for e in root.findall("./RegistrationInfo/Date"):
-                    d['Date'] = e.text
+                    d['Date'] = e.text or ''
                 for e in root.findall("./RegistrationInfo/Description"):
-                    d['Description'] = e.text
+                    d['Description'] = e.text or ''
                 for e in root.findall("./Actions"):
                     d['Actions'] = self.visit_all_children(e)
                 for e in root.findall("./Settings/Enabled"):
-                    d['Enabled'] = e.text
+                    d['Enabled'] = e.text or ''
                 for e in root.findall("./Settings/Hidden"):
-                    d['Hidden'] = e.text
+                    d['Hidden'] = e.text or ''
                 for t in root.findall("./Triggers/*"):
                     d['Triggers'] = self.visit_all_children(t)
 
@@ -501,7 +550,8 @@ class Autoruns(hivelist.HiveList):
 
                 return d
             except UnicodeDecodeError as e:
-                sys.stderr.write('UnicodeDecodeError for: {}\n'.format(repr(raw)))
+                debug.warning('Error while parsing the following task: {}'.format(f_name))
+                debug.debug('UnicodeDecodeError for: {}'.format(repr(raw)))
 
     def visit_all_children(self, node):
         d = {}
@@ -515,20 +565,19 @@ class Autoruns(hivelist.HiveList):
 
     def calculate(self):
         self.get_dll_list()
+        self.regapi = registryapi.RegistryApi(self._config)
+        self.currentcs = self.regapi.reg_get_currentcontrolset() or "ControlSet001"
+        asep_list = ['autoruns', 'services', 'appinit', 'winlogon', 'tasks', 'activesetup', 'sdb']
+        os_major = utils.load_as(self._config).profile.metadata.get('major', 0)
+
+        # If all_offsets is empty then regapi was unable to find
+        # hive offsets and we exit with an error message
+        if not self.regapi.all_offsets:
+            debug.error('Unable to find registry hives.')
 
         if self._config.ASEP_TYPE:
-            asep_list = [s for s in self._config.ASEP_TYPE.split(',')]
-        else:
-            asep_list = ['autoruns', 'services', 'appinit', 'winlogon', 'tasks', 'activesetup', 'sdb']
-
-        self.autoruns = []
-        self.services = []
-        self.appinit_dlls = []
-        self.winlogon = []
-        self.winlogon_registrations = []
-        self.tasks = []
-        self.activesetup = []
-        self.sdb = []
+            debug.debug('Config: {}'.format(self._config.ASEP_TYPE))
+            asep_list = [s for s in self._config.ASEP_TYPE.replace(' ', '').split(',')]
 
         # Scan for ASEPs and populate the lists
         if 'autoruns' in asep_list:
@@ -539,7 +588,8 @@ class Autoruns(hivelist.HiveList):
             self.appinit_dlls = self.get_appinit_dlls()
         if 'winlogon' in asep_list:
             self.winlogon = self.get_winlogon()
-            self.winlogon_registrations = self.get_winlogon_registrations()
+            if os_major == 5:
+                self.winlogon_registrations = self.get_winlogon_registrations()
         if 'tasks' in asep_list:
             self.tasks = self.get_tasks()
         if 'activesetup' in asep_list:
@@ -547,32 +597,90 @@ class Autoruns(hivelist.HiveList):
         if 'sdb' in asep_list:
             self.sdb = self.get_sdb()
 
-        data = self.get_unified_output_data()
-        for result in data:
-            yield result
+        #Returns a generator to generator() that generates the unified output data
+        return self.get_unified_output_data()
 
     def get_unified_output_data(self):
-        data = []
-        for hive in self.autoruns:
-            source = hive.split('\\')[-1]
-            if source == "NTUSER.DAT":
-                source = hive.split('\\')[-2] + '\\' + source
-            for key, timestamp in self.autoruns[hive]:
-                for name, executable, pids in self.autoruns[hive][(key, timestamp)]:
-                    data.append([executable, 'Autoruns', timestamp, name, ", ".join([str(p) for p in pids]) or "", hive, key, name, ""])
-        for line in self.winlogon_registrations:
-            data.append([(line[0] or ''), 'Winlogon (Notify)', line[2], 'Hooks: {0}'.format(", ".join([e[1] for e in line[1]]), len(line[1])), ", ".join([str(p) for p in line[3]]) or "", "Windows/System32/config/SOFTWARE", "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Notify\\" + line[4] , "", ""])
-        for line in self.winlogon:
-            data.append([line[1].replace('\x00', ''), 'Winlogon ({})'.format(line[0]), line[2], "Default value: {}".format(line[3]), ", ".join([str(p) for p in line[4]]) or "" , "Windows/System32/config/SOFTWARE", "Microsoft\\Windows NT\\CurrentVersion\\Winlogon", line[0], ""])
-        for name, timestamp, details, start, type, executable, entry, pids in self.services:
-            data.append([executable.replace('\x00', ''),'Services',timestamp,"{0} - {1} ({2} - {3})".format(name, ("" if details is None else details.replace('\x00', '')) , type, start), ", ".join([str(p) for p in pids]) or "", "Windows/System32/config/SYSTEM", "ControlSet001\\Services\\" + name , "", "" if entry is None else entry])
+        for exe_path, hive, key, timestamp, val_name, pids in self.autoruns:
+            yield [exe_path,
+                   'Autoruns',
+                   timestamp,
+                   val_name,
+                   ", ".join([str(p) for p in pids]),
+                   hive,
+                   key,
+                   val_name,
+                   ""]
+        for exe_path, key, timestamp, val_name, pids in self.appinit_dlls:
+            yield [exe_path,
+                   'AppInit Dlls',
+                   timestamp,
+                   '-',
+                   ", ".join([str(p) for p in pids]),
+                   "Windows/System32/config/SOFTWARE",
+                   key,
+                   val_name,
+                   ""]
+        for exe_path, events, timestamp, key, pids in self.winlogon_registrations:
+            yield [exe_path,
+                   'Winlogon (Notify)',
+                   timestamp,
+                   'Hooks: {0}'.format(", ".join([e[1] for e in events])),
+                   ", ".join([str(p) for p in pids]),
+                   "Windows/System32/config/SOFTWARE",
+                   key,
+                   "Dllname",
+                   ""]
+        for val_name, exe_path, timestamp, common_value, key, pids in self.winlogon:
+            yield [exe_path,
+                   'Winlogon ({})'.format(val_name),
+                   timestamp,
+                   "Default value: {}".format(common_value),
+                   ", ".join([str(p) for p in pids]),
+                   "Windows/System32/config/SOFTWARE",
+                   key,
+                   val_name,
+                   ""]
+        for key, timestamp, display_name, start, type, exe_path, entry, pids in self.services:
+            yield [exe_path,
+                   'Services',
+                   timestamp,
+                   "{0} - {1} ({2} - {3})".format(key.split('\\')[-1], display_name, type, start),
+                   ", ".join([str(p) for p in pids]),
+                   "Windows/System32/config/SYSTEM",
+                   key,
+                   "",
+                   entry]
         for name, task, task_xml, pids in self.tasks:
-            data.append([task['Actions']['Exec']['Command'],'Scheduled Tasks', task['Date'], "{} ({})".format(name, task.get('Description', "N/A")), ", ".join([str(p) for p in pids]) or "", "", "", "", ""])
-        for name, date, pids in self.activesetup:
-            data.append([name,"Active Setup", date, "-", ", ".join([str(p) for p in pids]) or "", "Windows/System32/config/SOFTWARE", "", "StubPath", ""])
-        for desc, path, timestamp, pids in self.sdb:
-            data.append([path, "SDB", timestamp, desc, "", "", "", "", "", ""])
-        return data
+            yield [task['Actions']['Exec']['Command'],
+                   'Scheduled Tasks',
+                   task.get('Date', ""),
+                   "{} ({})".format(name, task.get('Description', "N/A")),
+                   ", ".join([str(p) for p in pids]),
+                   "",
+                   "",
+                   "",
+                   ""]
+        for exe_path, timestamp, key, pids in self.activesetup:
+            yield [exe_path,
+                   "Active Setup",
+                   timestamp,
+                   "-",
+                   ", ".join([str(p) for p in pids]),
+                   "Windows/System32/config/SOFTWARE",
+                   key,
+                   "StubPath",
+                   ""]
+        for desc, exe_path, timestamp, key, pids in self.sdb:
+            yield [exe_path,
+                   "SDB",
+                   timestamp,
+                   desc,
+                   ", ".join([str(p) for p in pids]),
+                   "Windows/System32/config/SOFTWARE",
+                   key,
+                   "",
+                   ""]
 
     def unified_output(self, data):
         """This standardizes the output formatting"""
@@ -601,98 +709,51 @@ class Autoruns(hivelist.HiveList):
                            ("PIDs", "15")
                            ])
 
-        for line in self.winlogon_registrations:
-            self.table_row(outfd, line[0] or '', 'Winlogon (Notify)', line[2], 'Hooks: {0}'.format(", ".join([e[1] for e in line[1]]), len(line[1])), ", ".join([str(p) for p in line[3]]) or "-")
-
-        for line in self.winlogon:
-            self.table_row(outfd, line[1].replace('\x00', ''), 'Winlogon ({})'.format(line[0]), line[2], "Default value: {}".format(line[3]), ", ".join([str(p) for p in line[4]]) or "-")
-
-        for hive in self.autoruns:
-            source = hive.split('\\')[-1]
-            if source == "NTUSER.DAT":
-                source = hive.split('\\')[-2] + '\\' + source
-
-            for key, timestamp in self.autoruns[hive]:
-                for name, dat, pids in self.autoruns[hive][(key, timestamp)]:
-                    details = name
-                    executable = dat
-                    self.table_row(outfd, executable, source + " ({})".format(key.split('\\')[-1]), timestamp, details, ", ".join([str(p) for p in pids]) or "-")
-
-        for name, timestamp, details, start, type, executable, entry, pids in self.services:
-            if entry is not None:
-                name += " (Loads: {})".format(entry)
-            self.table_row(outfd,
-                        executable.replace('\x00', ''),
-                        'Services',
-                        timestamp,
-                        "{0} - {1} ({2} - {3})".format(name, "" if details is None else details.replace('\x00', ''), type, start), ", ".join([str(p) for p in pids]) or "-")
-
-        for name, task, task_xml, pids in self.tasks:
-            self.table_row(outfd,
-                           task['Actions']['Exec']['Command'],
-                           'Scheduled Tasks',
-                           task['Date'],
-                           "{} ({})".format(name, task.get('Description', "N/A")),
-                           ", ".join([str(p) for p in pids]) or "-")
-
-        for name, date, pids in self.activesetup:
-            self.table_row(outfd,
-                           name,
-                           "Active Setup",
-                           date,
-                           "-",
-                           ", ".join([str(p) for p in pids]) or "-")
-
-        for desc, path, timestamp, pids in self.sdb:
-            self.table_row(outfd,
-                           path,
-                           "SDB",
-                           timestamp,
-                           desc)
+        for exe, source, timestamp, details, pids, hive, key, name, share_dll in data:
+            if share_dll:
+                exe = share_dll
+            self.table_row(outfd, exe, source, timestamp, details, pids)
 
     def render_text(self, outfd, data):
+        previous_source = ""
+        for exe, source, timestamp, details, pids, hive, key, name, share_dll in data:
+            if source != previous_source:
+                outfd.write("\n\n")
+                outfd.write("{:=<50}\n\n".format(source))
 
-        if self.autoruns:
-            outfd.write("\n\n")
-            outfd.write("{:=<50}\n\n".format("Autoruns "))
-            for hive in self.autoruns:
+            if source == "Services":
+                outfd.write("Service: {}\n".format(details))
+                outfd.write("    Image path: {0} (Last modified: {1})\n".format(exe, timestamp))
+                outfd.write("    PIDs: {}\n".format(pids))
+                if share_dll:
+                    outfd.write("    Loads: {}\n".format(share_dll))
+            elif source == "Autoruns":
                 outfd.write("Hive: {}\n".format(hive))
-                for key, timestamp in self.autoruns[hive]:
-                    outfd.write("    {0} (Last modified: {1})\n".format(key, timestamp))
-                    for name, dat, pids in self.autoruns[hive][(key, timestamp)]:
-                        outfd.write("        {0:30} : {1} (PIDs: {2})\n".format(name, dat, ", ".join([str(p) for p in pids]) or "-"))
-                outfd.write("\n")
-
-        if self.services:
-            outfd.write("\n\n")
-            outfd.write("{:=<50}\n\n".format("Services "))
-            for name, timestamp, display_name, startup, type, executable, entry, pids in self.services:
-                outfd.write("Service: {0} ({1}) - {2}, {3}\n".format(name, display_name, type, startup))
-                outfd.write("    Image path: {0} (Last modified: {1})\n".format(executable, timestamp))
-                outfd.write("    PIDs: {}\n".format(", ".join([str(p) for p in pids]) or "-"))
-                if entry:
-                    outfd.write("    Loads: {}\n".format(entry))
-                outfd.write("\n")
-
-        if self.winlogon:
-            outfd.write("\n\n")
-            outfd.write("{:=<50}\n\n".format("Winlogon "))
-            for value, data, timestamp, default, pids in self.winlogon:
-                outfd.write("{0}: {1} (default: {2})\n".format(value, data.replace('\x00', ''), default))
-                outfd.write("    PIDs: {}\n".format(", ".join([str(p) for p in pids]) or "-"))
+                outfd.write("    {0} (Last modified: {1})\n".format(key, timestamp))
+                outfd.write("        {0:30} : {1} (PIDs: {2})\n".format(exe, details, pids))
+            elif source == "Active Setup":
+                outfd.write("Command line: {}\nLast-written: {} (PIDs: {})\n".format(exe, timestamp, pids))
+            elif source == "SDB":
+                previous_source = source
+                continue
+            elif source == "Winlogon (Notify)":
+                outfd.write("{0} (Last write time: {1})\n".format(exe, timestamp))
+                outfd.write("    PIDs: {}\n".format(pids))
+                outfd.write("    {}\n".format(details))
+            elif "Winlogon" in source:
+                outfd.write("{0}: {1}\n".format(name, exe))
+                outfd.write("    {}\n".format(details))
+                outfd.write("    PIDs: {}\n".format(pids))
                 outfd.write("    Last write time: {}\n".format(timestamp))
-                outfd.write("\n")
+            elif source == "AppInit Dlls":
+                outfd.write("Exe path: {}\n".format(exe))
+                outfd.write("PIDS: {}\n".format(pids))
+            elif source == "Scheduled Tasks":
+                previous_source = source
+                continue
 
-        if self.winlogon_registrations:
-            outfd.write("\n\n")
-            outfd.write("{:=<50}\n\n".format("Winlogon Notify registrations "))
-            for image, hooks, timestamp, pids in self.winlogon_registrations:
-                outfd.write("{0} (Last write time: {1})\n".format(image, timestamp))
-                outfd.write("    PIDs: {}\n".format(", ".join([str(p) for p in pids]) or "-"))
-                outfd.write("    Hooks: \n")
-                for hook in hooks:
-                    outfd.write("        {0:<20} {1}\n".format(hook[0], hook[1]))
-                outfd.write("\n")
+            outfd.write("\n")
+            previous_source = source
 
         if self.tasks:
             outfd.write("\n\n")
@@ -702,12 +763,6 @@ class Autoruns(hivelist.HiveList):
                 outfd.write(get_indented_dict(task))
                 outfd.write('\n')
                 outfd.write("Raw XML:\n\n---------\n{}\n---------\n\n\n".format(task_xml))
-
-        if self.activesetup:
-            outfd.write("\n\n")
-            outfd.write("{:=<50}\n\n".format("Active Setup "))
-            for imagename, last_write_time, pids in self.activesetup:
-                outfd.write("Command line: {}\nLast-written: {} (PIDs: {})\n\n".format(imagename, last_write_time, ", ".join([str(p) for p in pids]) or "-"))
 
         if self.sdb:
             outfd.write("\n\n")


### PR DESCRIPTION
 - Updated appinit dlls to create entries based on space or , per microsofts documents
 - Added appinit dll to autoruns collection. It was never called in previous code.
 - Moved all registry access over to registryapi.
 - Added exception handling/logging to all methods accessing/parsing registry data.
 - Fixed issue where verbose option was not updated.
 - Made autoruns subclass of AbstractWindowsCommand as most plugins are.
 - Updated render_table and render_text to use output produced by calculate() instead of accessing data dictionaries
 - Added check to bail if registryapi was unable to find any registry hives instead of allowing to run and producing no output for users.
 - Added check to winlogon notify so it would only run if the system being analyzed is pre vista as those systems are the only ones that use winlogon notify.
 - Added more sanitization to data pulled from registry
 - Added more checking so we do not produce entries if no exe/dll was found.
 - Gerneral code cleanup and removed unnecessary librarires/code.